### PR TITLE
Added support for ignore option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -167,6 +167,9 @@ var main = function main() {
         default: false,
         type: 'boolean',
         describe: 'Show verbose message'
+    }).option('i', {
+        alias: 'ignore',
+        describe: 'Glob pattern for files that should be ignored'
     }).alias('h', 'help').help('h');
 
     var argv = yarg.argv;
@@ -206,7 +209,8 @@ var main = function main() {
     var cache = !!argv.w;
 
     if (!argv.w) {
-        (0, _glob2.default)(filesPattern, null, function (err, pathNames) {
+        var globOptions = argv.i ? { ignore: argv.i } : null;
+        (0, _glob2.default)(filesPattern, globOptions, function (err, pathNames) {
             if (err) {
                 console.error(err);
                 return;
@@ -220,7 +224,8 @@ var main = function main() {
     } else {
         console.info('Watching ' + filesPattern + ' ...\n');
 
-        var watcher = _chokidar2.default.watch(filesPattern);
+        var chokidarOptions = argv.i ? { ignored: argv.i } : null;
+        var watcher = _chokidar2.default.watch(filesPattern, _chokidar2.default);
         watcher.on('add', createTypingsForFileOnWatch(creator, cache, argv.v));
         watcher.on('change', createTypingsForFileOnWatch(creator, cache, argv.v));
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -215,7 +215,7 @@ const main = () => {
         console.info(`Watching ${filesPattern} ...\n`);
         
         const chokidarOptions = argv.i ? {ignored: argv.i} : null;
-        const watcher = chokidar.watch(filesPattern, chokidar);
+        const watcher = chokidar.watch(filesPattern, chokidarOptions);
         watcher.on('add', createTypingsForFileOnWatch(creator, cache, argv.v));
         watcher.on('change', createTypingsForFileOnWatch(creator, cache, argv.v));
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -155,6 +155,10 @@ const main = () => {
             type: 'boolean',
             describe: 'Show verbose message',
         })
+        .option('i', {
+            alias: 'ignore',
+            describe: 'Glob pattern for files that should be ignored',
+        })
 
         .alias('h', 'help')
         .help('h');
@@ -195,7 +199,8 @@ const main = () => {
     const cache = !!argv.w;
 
     if (!argv.w) {
-        glob(filesPattern, null, (err, pathNames) => {
+        const globOptions = argv.i ? {ignore: argv.i} : null;
+        glob(filesPattern, globOptions, (err, pathNames) => {
             if (err) {
                 console.error(err);
                 return;
@@ -208,8 +213,9 @@ const main = () => {
         });
     } else {
         console.info(`Watching ${filesPattern} ...\n`);
-
-        const watcher = chokidar.watch(filesPattern);
+        
+        const chokidarOptions = argv.i ? {ignored: argv.i} : null;
+        const watcher = chokidar.watch(filesPattern, chokidar);
         watcher.on('add', createTypingsForFileOnWatch(creator, cache, argv.v));
         watcher.on('change', createTypingsForFileOnWatch(creator, cache, argv.v));
     }


### PR DESCRIPTION
Adds support for ignoring files matching a pattern.

E.g.:
App.scss <- Should use modules and generate types
App.global.scss <- Should not use modules and not generate types

I did not see an option for using an ignore pattern hence this PR. It should add support for ignore patterns both when running normally and when watching files.